### PR TITLE
Allow custom tags for kubernetes image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ARG GO_IMAGE=briandowns/rancher-build-base:v0.1.1
 FROM ${UBI_IMAGE} as ubi
 
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
+ARG K8S_TAG=""
+ARG TAG=""
+
 RUN apt update     && \ 
     apt upgrade -y && \ 
     apt install -y ca-certificates git bash rsync
@@ -12,8 +14,8 @@ RUN apt update     && \
 RUN git clone --depth=1 https://github.com/kubernetes/kubernetes.git
 RUN cd /go/kubernetes                  && \
     git fetch --all --tags --prune     && \
-    git checkout tags/${TAG} -b ${TAG} && \
-    make all
+    git checkout tags/${K8S_TAG} -b ${K8S_TAG} && \
+    KUBE_GIT_VERSION=${TAG} make all
 
 FROM ubi
 RUN microdnf update -y           && \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ SEVERITIES = HIGH,CRITICAL
 
 .PHONY: all
 all:
-	docker build --build-arg TAG=$(TAG) -t ranchertest/kubernetes:$(TAG) .
+	docker build \
+	--build-arg K8S_TAG=$(shell echo $(TAG) | grep -oP "^v(([0-9]+)\.([0-9]+)\.([0-9]+))") \
+	--build-arg TAG=$(TAG) -t ranchertest/kubernetes:$(shell echo $(TAG) | sed -e 's/+/-/g') .
 
 .PHONY: image-push
 image-push:


### PR DESCRIPTION
This PR allows the build with custom tags for rke2, for example:
```
TAG=v1.18.5-alpha6+rke2 make
```

This will result in compiling k8s with this tag and still work off the v1.18.5 upstream tag