### PR TITLE
Upgrade k3s-root version and remove ubi iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN chmod -v +x /usr/local/go/bin/go-*.sh
 
 FROM build-k8s-codegen AS build-k8s
 ARG ARCH="amd64"
-ARG K3S_ROOT_VERSION="v0.8.1"
+ARG K3S_ROOT_VERSION="v0.9.1"
 ADD https://github.com/k3s-io/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${ARCH}.tar /opt/k3s-root/k3s-root.tar
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root --wildcards --strip-components=2 './bin/aux/*tables*'
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root './bin/ipset'
@@ -77,8 +77,7 @@ RUN kube-proxy --version
 
 FROM ubi AS kubernetes
 RUN microdnf update -y           && \
-    microdnf install -y iptables    \
-    which                           \
+    microdnf install which          \
     conntrack-tools              && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
Upgrade k3s-root version to remove this upstream iptables bug: https://github.com/rancher/rke2/issues/1229

Do not install iptables from ubi package manager as k3s-root is already providing statically-built iptables and using a newer version

Signed-off-by: Manuel Buil <mbuil@suse.com>