### PR TITLE
Bump golang versions to v1.15.15b5/v1.16.7b7 to track upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(TAG),)
 TAG := v1.21.3-rke2dev$(BUILD_META)
 endif
 
-GOLANG_VERSION := $(shell if echo $(TAG) | grep -qE '^v1\.(18|19|20)\.'; then echo v1.15.14b5; else echo v1.16.6b7; fi)
+GOLANG_VERSION := $(shell if echo $(TAG) | grep -qE '^v1\.(18|19|20)\.'; then echo v1.15.15b5; else echo v1.16.7b7; fi)
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))


### PR DESCRIPTION
Signed-off-by: Brad Davidson <brad.davidson@rancher.com>