### PR TITLE
Don't wait for s390x to finish before pushing the manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -125,5 +125,4 @@ steps:
     - tag
 depends_on:
   - linux-amd64
-  - linux-s390x
 ...


### PR DESCRIPTION
We can revert this after the release, and perhaps after some investigation as to why s390x is so slow to build.