### PR TITLE
Suppress the output of the `which yq` command so it is not captured in the output of version script

### DIFF
--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(dirname $0)
 
-which yq || go get github.com/mikefarah/yq/v4
+which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.23.1
 
 K8S_VERSION=$(./semver-parse.sh $1 all)
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"


### PR DESCRIPTION
Also, use `go install` instead of `go get` because `go get` is removed starting in go 1.17
https://go.dev/doc/go-get-install-deprecation#:~:text=Starting%20in%20Go%201.17%2C%20installing,mod%20

Signed-off-by: Phan Le <phan.le@suse.com>