### PR TITLE
Remove goboring traces from build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ K3S_ROOT_VERSION ?= v0.10.1
 BUILD_META := -build$(shell date +%Y%m%d)
 
 ifeq ($(TAG),)
-TAG := v1.22.5-rke2dev$(BUILD_META)
+TAG := v1.24.4-rke2dev$(BUILD_META)
 endif
 
 GOLANG_VERSION := $(shell ./scripts/golang-version.sh $(TAG))

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -14,5 +14,5 @@ K8S_VERSION=$(./semver-parse.sh $1 all)
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
 GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
 
-GOBORING_TAG=$(curl -s -H ${BUILD_BASE_REQ_HEADERS} ${BUILD_BASE_RELEASE_URL} | jq -r '[ .[] | select(.tag_name| contains("'"${GOLANG_VERSION}"'")) | .tag_name ] | sort | last'
+GOBORING_TAG=$(curl -s -H ${BUILD_BASE_REQ_HEADERS} ${BUILD_BASE_RELEASE_URL} | jq -r '[ .[] | select(.tag_name|contains("'${GOLANG_VERSION}'")) | .tag_name ] | sort | last')
 echo ${GOBORING_TAG}

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -4,12 +4,16 @@ set -x
 
 cd $(dirname $0)
 
+BUILD_BASE_RELEASE_URL=https://api.github.com/repos/rancher/image-build-base/releases
+BUILD_BASE_REQ_HEADERS="Accept: application/vnd.github+json"
 which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.23.1
 
-K8S_VERSION=$(./semver-parse.sh $1 all)
-DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
-GOBORING_RELEASES_URL="https://raw.githubusercontent.com/golang/go/dev.boringcrypto/misc/boring/RELEASES"
-GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
-GOBORING_VERSION=$(curl -sL  "${GOBORING_RELEASES_URL}" | awk "/${GOLANG_VERSION}b.+ [0-9a-f]+ src / {sub(/^go/, \"v\", \$1); print \$1}")
+which jq > /dev/null || curl -Ss -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/bin/jq
 
-echo ${GOBORING_VERSION}
+K8S_VERSION=$(./semver-parse.sh $1 all)
+
+DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
+GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
+
+GOBORING_TAG=$(curl -s -H ${BUILD_BASE_REQ_HEADERS} ${BUILD_BASE_RELEASE_URL} | jq '.[] | select(.tag_name| contains("'"${GOLANG_VERSION}"'"))' | jq -r .tag_name | head -1)
+echo ${GOBORING_TAG}

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -7,13 +7,12 @@ cd $(dirname $0)
 BUILD_BASE_RELEASE_URL=https://api.github.com/repos/rancher/image-build-base/releases
 BUILD_BASE_REQ_HEADERS="Accept: application/vnd.github+json"
 which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.23.1
-
-which jq > /dev/null || curl -Ss -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/bin/jq
+which jq > /dev/null || apk add -q --no-progress jq
 
 K8S_VERSION=$(./semver-parse.sh $1 all)
 
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
 GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
 
-GOBORING_TAG=$(curl -s -H ${BUILD_BASE_REQ_HEADERS} ${BUILD_BASE_RELEASE_URL} | jq '.[] | select(.tag_name| contains("'"${GOLANG_VERSION}"'"))' | jq -r .tag_name | head -1)
+GOBORING_TAG=$(curl -s -H ${BUILD_BASE_REQ_HEADERS} ${BUILD_BASE_RELEASE_URL} | jq -r '[ .[] | select(.tag_name| contains("'"${GOLANG_VERSION}"'")) | .tag_name ] | sort | last'
 echo ${GOBORING_TAG}


### PR DESCRIPTION
- Removing goboring traces from the go version script
- Add a lookup for image-build-base releases instead and chose the latest patch version

This change is needed for the recent deletion of goboring branch and its merge to the main branch