### PR TITLE
Bump golang and default tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.16.12b7
+  image: rancher/hardened-build-base:v1.20.3b1
   volumes:
     - name: docker
       path: /var/run/docker.sock
@@ -18,7 +18,7 @@ steps:
     - make image-build
 
 - name: scan
-  image: rancher/hardened-build-base:v1.16.12b7
+  image: rancher/hardened-build-base:v1.20.3b1
   volumes:
     - name: docker
       path: /var/run/docker.sock
@@ -34,7 +34,7 @@ steps:
       - refs/tags/*
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.12b7
+  image: rancher/hardened-build-base:v1.20.3b1
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push
@@ -71,7 +71,7 @@ node:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.16.12b7
+  image: rancher/hardened-build-base:v1.20.3b1
   failure: ignore
   environment:
     GITHUB_TOKEN:
@@ -83,7 +83,7 @@ steps:
   - make image-build
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.12b7
+  image: rancher/hardened-build-base:v1.20.3b1
   failure: ignore
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
-ARG GO_IMAGE=rancher/hardened-build-base:UNSET_GO_IMAGE_ARG
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
+ARG GO_IMAGE=rancher/hardened-build-base:v1.20.3b1
 
 FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as build
@@ -58,7 +58,7 @@ RUN chmod -v +x /usr/local/go/bin/go-*.sh
 
 FROM build-k8s-codegen AS build-k8s
 ARG ARCH="amd64"
-ARG K3S_ROOT_VERSION="v0.9.1"
+ARG K3S_ROOT_VERSION="v0.12.1"
 ADD https://github.com/k3s-io/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${ARCH}.tar /opt/k3s-root/k3s-root.tar
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root --wildcards --strip-components=2 './bin/aux/*tables*'
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root './bin/ipset'

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,15 @@ ORG ?= rancher
 PKG ?= github.com/kubernetes/kubernetes
 SRC ?= github.com/kubernetes/kubernetes
 TAG ?= ${DRONE_TAG}
-TOKEN ?= ${GITHUB_TOKEN}
-K3S_ROOT_VERSION ?= v0.10.1
+K3S_ROOT_VERSION ?= v0.12.1
 
 BUILD_META := -build$(shell date +%Y%m%d)
 
 ifeq ($(TAG),)
-TAG := v1.25.4-rke2dev$(BUILD_META)
+TAG := v1.26.3-rke2dev$(BUILD_META)
 endif
 
-GOLANG_VERSION := $(shell ./scripts/golang-version.sh $(TAG) $(TOKEN))
+GOLANG_VERSION := $(shell ./scripts/golang-version.sh $(TAG))
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -4,23 +4,19 @@ set -x
 
 cd $(dirname $0)
 
-BUILD_BASE_RELEASE_URL=https://api.github.com/repos/rancher/image-build-base/releases
-BUILD_BASE_REQ_HEADERS="Accept: application/vnd.github+json"
-BUILD_BASE_TOKEN_HEADER="Authorization: Bearer $2"
-if [ "${2}" == "" ]; then
-    BUILD_BASE_TOKEN_HEADER=""
-fi
-
 which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.23.1
-which jq > /dev/null || apk add -q --no-progress jq
 
 K8S_VERSION=$(./semver-parse.sh $1 all)
-
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
+GOBORING_RELEASES_URL="https://raw.githubusercontent.com/golang/go/dev.boringcrypto/misc/boring/RELEASES"
 GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
+GOLANG_MINOR=$(echo $GOLANG_VERSION | awk -F. '{print $2}')
 
-GOBORING_TAG=$(curl -s -H "${BUILD_BASE_TOKEN_HEADER}" -H "${BUILD_BASE_REQ_HEADERS}" ${BUILD_BASE_RELEASE_URL} | jq -r '[ .[] | select(.tag_name|contains("'${GOLANG_VERSION}'")) | .tag_name ] | sort | last')
-if [ -z "${BUILD_BASE_TOKEN_HEADER}" ]; then
-    GOBORING_TAG=$(curl -s -H "${BUILD_BASE_REQ_HEADERS}" ${BUILD_BASE_RELEASE_URL} | jq -r '[ .[] | select(.tag_name|contains("'${GOLANG_VERSION}'")) | .tag_name ] | sort | last')
+# goboring is built into golang as of 1.19; tag is 'b1' for all releases
+if [ "$GOLANG_MINOR" -ge "19" ]; then
+  GOBORING_VERSION="v${GOLANG_VERSION}b1"
+else
+  GOBORING_VERSION=$(curl -sL  "${GOBORING_RELEASES_URL}" | awk "/${GOLANG_VERSION}b.+ [0-9a-f]+ src / {sub(/^go/, \"v\", \$1); print \$1}")
 fi
-echo ${GOBORING_TAG}
+
+echo ${GOBORING_VERSION}


### PR DESCRIPTION
Bump to latest versions.

Also fix golang version script to not require scraping image-build-base tags; goboring version will be `b1` for all 1.19+ golang releases.