### PR TITLE
Bump k3s-root for arm64 64k page size fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN chmod -v +x /usr/local/go/bin/go-*.sh
 
 FROM build-k8s-codegen AS build-k8s
 ARG ARCH="amd64"
-ARG K3S_ROOT_VERSION="v0.12.1"
+ARG K3S_ROOT_VERSION="v0.13.0"
 ADD https://github.com/k3s-io/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${ARCH}.tar /opt/k3s-root/k3s-root.tar
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root --wildcards --strip-components=2 './bin/aux/*tables*'
 RUN tar xvf /opt/k3s-root/k3s-root.tar -C /opt/k3s-root './bin/ipset'


### PR DESCRIPTION
Resolves crash on arm64 nodes with large page sizes:
* https://github.com/rancher/rke2/issues/4737
* https://github.com/k3s-io/k3s/issues/7335