### PR TITLE
Get latest build

### DIFF
--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -31,7 +31,7 @@ while [ -n "${NEXT_URL}" ] && [ $PAGE -lt $MAX_PAGE ]; do
   RESPONSE=$(curl -s "$NEXT_URL")
   NEXT_URL=$(echo "$RESPONSE" | yq -r '.next // ""')
   TAGS=$(echo "$RESPONSE" | yq -r '.results[].name')
-  TAG=$(echo "${TAGS}" | grep "${GOLANG_VERSION}b[0-9+]$" | head -n 1)
+  TAG=$(echo "${TAGS}" | grep "${GO_VERSION}b[0-9+]$" | head -n 1)
   if [ -n "$TAG" ]; then
     break
   fi
@@ -40,7 +40,7 @@ while [ -n "${NEXT_URL}" ] && [ $PAGE -lt $MAX_PAGE ]; do
 done
 
 if [ -z "${TAG}" ]; then
-  echo "No hardened-build-base tag found for Go ${GOLANG_VERSION}"
+  echo "No hardened-build-base tag found for Go ${GO_VERSION}"
   exit 1
 fi
 

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(dirname $0)
 
-which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.23.1
+which yq > /dev/null || go install github.com/mikefarah/yq/v4@v4.35.2
 
 K8S_VERSION=$(./semver-parse.sh $1 all)
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -16,7 +16,7 @@ fi
 GO_VERSION_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/.go-version"
 GO_VERSION=$(curl -sL "${GO_VERSION_URL}")
 
-if [ -z "${GO_VERSION}" ]; then
+if [[ "${GO_VERSION}" != "1."* ]]; then
   echo "No Go version found for Kubernetes ${K8S_VERSION}"
   exit 1
 fi

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -29,7 +29,7 @@ TAG=""
 
 while [ -n "${NEXT_URL}" ] && [ $PAGE -lt $MAX_PAGE ]; do
   RESPONSE=$(curl -s "$NEXT_URL")
-  NEXT_URL=$(echo "$RESPONSE" | yq -r '.next // empty')
+  NEXT_URL=$(echo "$RESPONSE" | yq -r '.next // ""')
   TAGS=$(echo "$RESPONSE" | yq -r '.results[].name')
   TAG=$(echo "${TAGS}" | grep "${GOLANG_VERSION}b[0-9+]$" | head -n 1)
   if [ -n "$TAG" ]; then

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -23,7 +23,7 @@ fi
 
 BASE_URL='https://hub.docker.com/v2/repositories/rancher/hardened-build-base/tags'
 NEXT_URL=$BASE_URL
-MAX_PAGE=5
+MAX_PAGE=10
 PAGE=0
 TAG=""
 


### PR DESCRIPTION
For a given Go version, there may be multiple hardened-build-base tags which match (e.g. v1.20.8b1, b1.20.8b2, etc.)

- Updates yq
- Uses .go-version file in Kubernetes repo instead of dependencies.yaml
- Removes path for versions of Go older than v1.19
- Removes hardcoded "b2" build suffix
- Retrieves list of hardened-build-base tags and outputs the most recent match