### PR TITLE
Bump k3s-root, again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORG ?= rancher
 PKG ?= github.com/kubernetes/kubernetes
 SRC ?= github.com/kubernetes/kubernetes
 TAG ?= ${DRONE_TAG}
-K3S_ROOT_VERSION ?= v0.12.1
+K3S_ROOT_VERSION ?= v0.13.0
 
 BUILD_META := -build$(shell date +%Y%m%d)
 


### PR DESCRIPTION
I missed the more important place that this was set in https://github.com/rancher/image-build-kubernetes/pull/48

* https://github.com/rancher/rke2/issues/4737
* https://github.com/k3s-io/k3s/issues/7335