### PR TITLE
fix push job permissions

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -9,6 +9,9 @@ permissions:
 
 jobs:
   push-multiarch:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - name: Check out code


### PR DESCRIPTION
Updates job permissions to allow the request of an OIDC token for vault access.
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings