### PR TITLE
Add timezone db and revert base image change that broke shared libraries required by kmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,7 @@ RUN kube-proxy --version
 
 FROM bci AS kubernetes
 RUN zypper update -y && \
-    zypper install -y which conntrack-tools kmod
-
+    zypper install -y which conntrack-tools kmod timezone
 COPY --from=build-k8s /opt/k3s-root/aux/ /usr/sbin/
 COPY --from=build-k8s /opt/k3s-root/bin/ /bin/
 COPY --from=build-k8s /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
Reverts https://github.com/rancher/image-build-kubernetes/pull/56, as kmod (modprobe et al) require shared libraries that should not be copied from bci to bci-busybox.
For:
* https://github.com/rancher/rke2/issues/7444
* https://github.com/rancher/rke2/issues/7331

Busybox does not support zstd compression, so if we want to support loading zstd-compressed kernel modules, we cannot use busybox. Ref: 
* https://github.com/facebook/zstd/issues/2806
* https://lists.busybox.net/pipermail/busybox/2021-September/089235.html