### PR TITLE
Fix golang.org/x/net CVEs via go.mod override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN echo $(/semver-parse.sh ${TAG} all)
 RUN git clone -b $(/semver-parse.sh ${TAG} all) --depth=1 -- https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/kubernetes
 WORKDIR ${GOPATH}/src/kubernetes
 
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
+
 # force code generation
 RUN make WHAT=cmd/kube-apiserver
 # build statically linked executables 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
-ARG GO_IMAGE=rancher/hardened-build-base:v1.26.4b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.26.5b1
 
 FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS build

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,20 @@
+# go-mod-overrides
+#
+# Tracks go.mod overrides applied on top of the upstream module to keep this
+# image CVE-free, even when upstream has not yet bumped the affected dependency.
+# Each non-comment line is passed verbatim to `go mod edit` at build time by the
+# shared scripts/go-mod-overrides.sh that ships in rancher/hardened-build-base.
+# Reference a CVE/advisory per entry so we know when it can be dropped (i.e. once
+# upstream catches up).
+#
+# Supported (anything `go mod edit` accepts), e.g.:
+#   -replace <old>[=<new>][@<version>]
+#   -require <path>@<version>
+#   -exclude <path>@<version>
+#   -dropreplace <path>[@<version>]
+
+# golang.org/x/net — pin to a patched release until upstream bumps it.
+#   CVE-2026-33814 — net/http2 DoS via malformed SETTINGS_MAX_FRAME_SIZE (fixed in v0.53.0)
+#   CVE-2026-39821 — x/net/idna Punycode privilege escalation           (fixed in v0.55.0)
+# Drop once upstream requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,20 +1,3 @@
-# go-mod-overrides
-#
-# Tracks go.mod overrides applied on top of the upstream module to keep this
-# image CVE-free, even when upstream has not yet bumped the affected dependency.
-# Each non-comment line is passed verbatim to `go mod edit` at build time by the
-# shared scripts/go-mod-overrides.sh that ships in rancher/hardened-build-base.
-# Reference a CVE/advisory per entry so we know when it can be dropped (i.e. once
-# upstream catches up).
-#
-# Supported (anything `go mod edit` accepts), e.g.:
-#   -replace <old>[=<new>][@<version>]
-#   -require <path>@<version>
-#   -exclude <path>@<version>
-#   -dropreplace <path>[@<version>]
-
-# golang.org/x/net — pin to a patched release until upstream bumps it.
-#   CVE-2026-33814 — net/http2 DoS via malformed SETTINGS_MAX_FRAME_SIZE (fixed in v0.53.0)
-#   CVE-2026-39821 — x/net/idna Punycode privilege escalation           (fixed in v0.55.0)
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
 # Drop once upstream requires golang.org/x/net >= v0.55.0.
 -replace golang.org/x/net=golang.org/x/net@v0.55.0


### PR DESCRIPTION
## Problem

The `hardened-kubernetes` image ships HIGH `golang.org/x/net` CVEs that are not yet fixed in the pinned upstream release:

- **CVE-2026-33814** — `net/http2` DoS via a malformed `SETTINGS_MAX_FRAME_SIZE` frame (fixed in `golang.org/x/net` v0.53.0)
- **CVE-2026-39821** — `x/net/idna` privilege escalation via incorrect Punycode label processing (fixed in `golang.org/x/net` v0.55.0)

## Fix

Use the shared, declarative go.mod override mechanism added to `rancher/hardened-build-base` in rancher/image-build-base#105:

- Add a repo-root **`go-mod-overrides`** file pinning `golang.org/x/net` to `v0.55.0` (covers both CVEs). Each entry references the CVE so it can be dropped once upstream catches up.
- Wire the Dockerfile builder to run the shared `go-mod-overrides.sh` (ships in `hardened-build-base`) against the cloned `kubernetes` module before code generation and the static builds.

## Notes

- The shared `go-mod-overrides.sh` was only just merged into `rancher/image-build-base` (#105) and is **not yet present in a released `hardened-build-base` tag**. This PR is intentionally opened ahead of that: it will build green once a new `hardened-build-base` tag is cut with the script and the `GO_IMAGE` in this repo is bumped to it.
- `kubernetes` is a large, multi-module tree built with `-mod=vendor` and its own staging `replace` directives. The override script runs `go mod tidy` + `go mod vendor`; the resulting vendor/go.sum changes should be validated in CI once the base image is available. If `go mod tidy` proves too aggressive here, we can switch this repo to a tidy-free variant of the override.

CVE source: rke2-toolbox scan report `scan-20260708-1`.
