### PR TITLE
Revert "Add trigger to release workflow"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,36 +47,3 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-
-  trigger-update-refs:
-    permissions:
-      id-token: write
-    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }},image=ubuntu22-full-x64
-    needs: push-multiarch
-    steps:
-      - name: "Read Secrets"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/github/rancher-release-team-auto-tagger/app-credentials appId | APP_ID ;
-            secret/data/github/repo/${{ github.repository }}/github/rancher-release-team-auto-tagger/app-credentials privateKey | PRIVATE_KEY
-
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
-          repositories: ecm-distro-tools
-          permission-actions: write
-
-      - name: Trigger k3s update refs workflow
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          VERSION="${TAG%%-*}"
-          gh workflow run update-k3s-references.yml \
-            --repo rancher/ecm-distro-tools \
-            --field versions="$VERSION" \
-            --field trigger-rke2="true"


### PR DESCRIPTION
Reverts rancher/image-build-kubernetes#134

Reverting this automation implementation to avoid integrating more `rancher` org into `k3s-io` org because of CNCF compliance. 