### PR TITLE
[DRAFT] Add go-mod-overrides with google.golang.org/grpc v1.82.1 for GHSA-hrxh-6v49-42gf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,13 @@ RUN chmod +x /semver-parse.sh
 RUN echo $(/semver-parse.sh ${TAG} all)
 RUN git clone -b $(/semver-parse.sh ${TAG} all) --depth=1 -- https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/kubernetes
 WORKDIR ${GOPATH}/src/kubernetes
-COPY go-mod-overrides ./go-mod-overrides
-RUN go-mod-overrides.sh ./go-mod-overrides
+# Override google.golang.org/grpc to remediate GHSA-hrxh-6v49-42gf (grpc-go < 1.82.1:
+# xDS RBAC authorization bypass and HTTP/2 Rapid Reset DoS). Applied inline rather than
+# via go-mod-overrides.sh to avoid running `go mod tidy` on the Kubernetes monorepo,
+# whose staging replace directives make tidy unreliable. Re-vendoring keeps the -mod=vendor
+# build consistent. Drop once upstream Kubernetes requires google.golang.org/grpc >= v1.82.1.
+RUN go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1 && \
+    go mod vendor
 
 # force code generation
 RUN make WHAT=cmd/kube-apiserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN chmod +x /semver-parse.sh
 RUN echo $(/semver-parse.sh ${TAG} all)
 RUN git clone -b $(/semver-parse.sh ${TAG} all) --depth=1 -- https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/kubernetes
 WORKDIR ${GOPATH}/src/kubernetes
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 
 # force code generation
 RUN make WHAT=cmd/kube-apiserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,11 @@ WORKDIR ${GOPATH}/src/kubernetes
 # Override google.golang.org/grpc to remediate GHSA-hrxh-6v49-42gf (grpc-go < 1.82.1:
 # xDS RBAC authorization bypass and HTTP/2 Rapid Reset DoS). Applied inline rather than
 # via go-mod-overrides.sh to avoid running `go mod tidy` on the Kubernetes monorepo,
-# whose staging replace directives make tidy unreliable. Re-vendoring keeps the -mod=vendor
+# whose staging replace directives make tidy unreliable. Kubernetes uses Go workspace
+# mode, so the replace goes in go.work and vendoring uses `go work vendor` to keep the
 # build consistent. Drop once upstream Kubernetes requires google.golang.org/grpc >= v1.82.1.
-RUN go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1 && \
-    go mod vendor
+RUN go work edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1 && \
+    go work vendor
 
 # force code generation
 RUN make WHAT=cmd/kube-apiserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
-ARG GO_IMAGE=rancher/hardened-build-base:v1.26.4b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.26.5b2
 
 FROM ${BCI_IMAGE} AS bci
 FROM ${GO_IMAGE} AS build
@@ -27,14 +27,9 @@ RUN chmod +x /semver-parse.sh
 RUN echo $(/semver-parse.sh ${TAG} all)
 RUN git clone -b $(/semver-parse.sh ${TAG} all) --depth=1 -- https://github.com/kubernetes/kubernetes.git ${GOPATH}/src/kubernetes
 WORKDIR ${GOPATH}/src/kubernetes
-# Override google.golang.org/grpc to remediate GHSA-hrxh-6v49-42gf (grpc-go < 1.82.1:
-# xDS RBAC authorization bypass and HTTP/2 Rapid Reset DoS). Applied inline rather than
-# via go-mod-overrides.sh to avoid running `go mod tidy` on the Kubernetes monorepo,
-# whose staging replace directives make tidy unreliable. Kubernetes uses Go workspace
-# mode, so the replace goes in go.work and vendoring uses `go work vendor` to keep the
-# build consistent. Drop once upstream Kubernetes requires google.golang.org/grpc >= v1.82.1.
-RUN go work edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1 && \
-    go work vendor
+# Apply go.mod/go.work overrides (see go-mod-overrides) for GHSA-hrxh-6v49-42gf.
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 
 # force code generation
 RUN make WHAT=cmd/kube-apiserver

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC authorization bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream Kubernetes requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,3 +1,0 @@
-# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
-# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
--replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,3 +1,7 @@
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
+# Drop once upstream Kubernetes requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0
+
 # google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC authorization bypass, HTTP/2 Rapid Reset DoS).
 # Drop once upstream Kubernetes requires google.golang.org/grpc >= v1.82.1.
 -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
Adds a `go-mod-overrides` file with the `google.golang.org/grpc` v1.82.1 override to remediate GHSA-hrxh-6v49-42gf (grpc-go < 1.82.1: xDS RBAC authorization bypass and HTTP/2 Rapid Reset DoS).

## Approach

Per brandond's review, this now uses the shared `go-mod-overrides.sh` mechanism like every other hardened image instead of a bespoke inline step:

- Replaced the inline `go work edit` / `go work vendor` block with the standard `COPY go-mod-overrides ./go-mod-overrides` + `RUN go-mod-overrides.sh ./go-mod-overrides` pattern.
- Added a `go-mod-overrides` file carrying the grpc override.
- Bumped `GO_IMAGE` from `rancher/hardened-build-base:v1.26.4b1` to `v1.26.5b2`.

The Kubernetes monorepo uses Go workspace mode, which the previous shared script did not support. That support is added in rancher/image-build-base#112 (detect `go.work`, apply overrides with `go work edit`, skip `go mod tidy`, vendor with `go work vendor`) and ships in the `v1.26.5b2` hardened-build-base release.

## Dependency / sequencing

This PR depends on rancher/image-build-base#112 merging and the `v1.26.5b2` hardened-build-base release being published. Once that image is available, CI here should pass. Keeping this in draft until the release is out.
