### PR TITLE
Get latest golang for same minor as upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,12 @@ jobs:
       id: get-TAG
       run: |
         echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
+
+    - name: Set the GO_IMAGE value
+      id: get-GO_IMAGE
+      run: |
+        echo GO_IMAGE=rancher/hardened-build-base:$(./scripts/golang-version.sh ${{ env.TAG }}) >> "$GITHUB_ENV"
+
     - name: Build container image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
@@ -29,6 +35,7 @@ jobs:
         file: Dockerfile
         build-args: |
           TAG=${{ env.TAG }}
+          GO_IMAGE=${{ env.GO_IMAGE }}
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -62,6 +69,12 @@ jobs:
       id: get-TAG
       run: |
         echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
+
+    - name: Set the GO_IMAGE value
+      id: get-GO_IMAGE
+      run: |
+        echo GO_IMAGE=rancher/hardened-build-base:$(./scripts/golang-version.sh ${{ env.TAG }}) >> "$GITHUB_ENV"
+
     - name: Build container image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
@@ -73,3 +86,5 @@ jobs:
         platforms: linux/arm64
         build-args: |
           TAG=${{ env.TAG }}
+          GO_IMAGE=${{ env.GO_IMAGE }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
+# NOTE: This DOES NOT determine the verison of Golang used to build Kubernetes.
+# See scripts/golang-version.sh for the logic used to determine the version used at build time.
 ARG GO_IMAGE=rancher/hardened-build-base:v1.26.7b2
 
 FROM ${BCI_IMAGE} AS bci

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ K3S_ROOT_VERSION ?= v0.15.2
 BUILD_META := -build$(shell date +%Y%m%d)
 
 ifeq ($(TAG),)
-TAG := v1.32.2-rke2dev$(BUILD_META)
+TAG := v1.36.4-rke2dev$(BUILD_META)
 endif
 
 ARCH=

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ## Build
 Build hardened kubernetes needs to include the rke2 release version and the build meta to work properly. Just running
-`make` will hardcode `v1.32.2-rke2dev-build<todaysdate>`. If you want to set your own versions for testing and when 
+`make` will hardcode `v1.36.4-rke2dev-build<todaysdate>`. If you want to set your own versions for testing and when 
 pushing a tag to the repo to make a release you will want to add the full version of kubernetes rke2 release and
 the build meta like the following.
 
 ```sh
-TAG=v1.32.2-rke2r1-build$(TZ=UTC date +%Y%m%d) make
+TAG=v1.36.4-rke2r1-build$(TZ=UTC date +%Y%m%d) make
 ```
 
 ## Pushing a Release
 You will need to know the RKE2 version you are releasing before you can build hardened kubernetes. For example a current
-release is `v1.32.2+rke2r1` and this translates to a hardened kubernetes build tag of `v1.32.2-rke2r1-build<date Ymd>`. 
+release is `v1.36.4+rke2r1` and this translates to a hardened kubernetes build tag of `v1.36.4-rke2r1-build<date Ymd>`. 
 Let this project build and release images and set your version in the [dockerfile](https://github.com/rancher/rke2/blob/master/Dockerfile)

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -14,9 +14,9 @@ if [ -z "${K8S_VERSION}" ] || [ "${K8S_VERSION}" == "v.." ]; then
 fi
 
 GO_VERSION_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/.go-version"
-GO_VERSION=$(curl -sL "${GO_VERSION_URL}")
+GO_MINOR_VERSION=$(curl -sL "${GO_VERSION_URL}" | cut -d. -f-2)
 
-if [[ "${GO_VERSION}" != "1."* ]]; then
+if [[ "${GO_MINOR_VERSION}" != "1."* ]]; then
   echo "No Go version found for Kubernetes ${K8S_VERSION}"
   exit 1
 fi
@@ -31,7 +31,7 @@ while [ -n "${NEXT_URL}" ] && [ $PAGE -lt $MAX_PAGE ]; do
   RESPONSE=$(curl -s "$NEXT_URL")
   NEXT_URL=$(echo "$RESPONSE" | yq -r '.next // ""')
   TAGS=$(echo "$RESPONSE" | yq -r '.results[].name')
-  TAG=$(echo "${TAGS}" | grep "${GO_VERSION}b[0-9+]$" | head -n 1)
+  TAG=$(echo "${TAGS}" | grep "${GO_MINOR_VERSION}\.[0-9+]b[0-9+]$" | head -n 1)
   if [ -n "$TAG" ]; then
     break
   fi
@@ -40,7 +40,7 @@ while [ -n "${NEXT_URL}" ] && [ $PAGE -lt $MAX_PAGE ]; do
 done
 
 if [ -z "${TAG}" ]; then
-  echo "No hardened-build-base tag found for Go ${GO_VERSION}"
+  echo "No hardened-build-base tag found for Go ${GO_MINOR_VERSION}"
   exit 1
 fi
 


### PR DESCRIPTION
Grabs the latest `hardened-build-base` tag for the same minor as upstream is using.